### PR TITLE
Reset global var searchResult before running gps import command

### DIFF
--- a/src/process-main/gps-tracks/gpsdump-import.js
+++ b/src/process-main/gps-tracks/gpsdump-import.js
@@ -15,6 +15,8 @@ let searchResult = {
  }
 
 ipcMain.on('gpsdump-import', (event, arrayIgc) => {
+  searchResult.igcBad.length = 0
+  searchResult.igcForImport.length = 0
   runSearchIgc(arrayIgc)  
   event.sender.send('gpsdump-result', searchResult)
 })


### PR DESCRIPTION
searchResult is a global in gpsdump-import and needs to reset for every run or the arrays igcBad and igcForImport keep on growing at every run.

This closes issue #7.