### PR TITLE
Do not import tracks that are already in the logbook

### DIFF
--- a/src/views/js/import.js
+++ b/src/views/js/import.js
@@ -853,7 +853,9 @@ function updateLogbook() {
       ipcRenderer.on('gpsdump-result', (event, result) => {
         if (result.igcForImport.length > 0) {
           result.igcForImport.forEach(element => {
-            nbInserted += dbadd.addFlight(element, i18n.gettext('To rename'))
+            if (element.forImport) {
+              nbInserted += dbadd.addFlight(element, i18n.gettext('To rename'))
+            }
           });
           hideWaiting()
           $('#table-content').removeClass('d-none')


### PR DESCRIPTION
gpsdump-import, disk-import, and igc-import all flag tracks that already are in the logbook by setting the `forImport` result attribute to false but this attribute is then ignored and the track is added to the database anyway.
This change simply prevents the addition of duplicates by checking on the value of the `forImport` attribute.

This closes issue #8.
